### PR TITLE
To test if there is a bug regarding starting key

### DIFF
--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -232,7 +232,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
       val items = Table[Item](t)
       val ops = for {
         _ <- items.putAll(list.toSet).toFreeT[SIO]
-        list <- items.scanPaginatedM[SIO](1)
+        list <- items.scanPaginatedM[SIO](2)
       } yield list
 
       scanamo.execT(ScanamoCats.ToStream)(ops).compile.toList.unsafeRunSync should contain theSameElementsAs expected


### PR DESCRIPTION
When I used this method with a page size larger than 1, I got 
```
 software.amazon.awssdk.services.dynamodb.model.DynamoDbException: Exclusive Start Key must have same size as table's key schema
 ```
